### PR TITLE
Fix committer check and use rolling window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ result
 
 # secrets
 .envrc.local
+
+# nix-direnv
+.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,14 @@
-{ pkgs ? import <nixpkgs> {} }:
+let
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/c1064e7c1ff1ddff79ba961ebfedb7d83eff13ed.tar.gz";
+    sha256 = "0na57f7pfq0v51lc9mwnyqyxqw57wis3zhglxz3mlhqg07fkx4g9";
+  };
+  pkgs = import nixpkgs {
+    overlays = [];
+    config = {};
+  };
+  inherit (pkgs.lib) fileset;
+in
 
 with pkgs.python3.pkgs;
 
@@ -10,7 +20,14 @@ let
   ]));
 in buildPythonPackage {
   name = "inactive-maintainers";
-  src = ./.;
+  src = fileset.toSource {
+    root = ./.;
+    fileset = fileset.unions [
+      ./inactive_maintainers
+      ./setup.py
+      ./setup.cfg
+    ];
+  };
   propagatedBuildInputs = [
     PyGithub
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,6 @@ mkShell {
       ps.mypy
       ps.PyGithub
     ]))
+    pyright
   ];
 }


### PR DESCRIPTION
This is closely related to my effort to automate committer deprecation, see https://github.com/NixOS/nixpkgs-committers/issues/62

In addition to some quality-of-life improvements this PR changes:
- Previously this script checked whether the committers have _authored_
  commits, which is not right in two ways: For one, the ones who merge
  PRs are the _committers_ not the authors. For another,
  author/committership can be faked. This patch fixes this by using the
  [repo activity API](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-activities), which checks exactly whether a specific person used
  their commit bit for anything

  This has the convenient side effect of both being much faster and not having the issue from https://github.com/NixOS/nixpkgs/issues/88867#issuecomment-2603169125 (I'm pretty sure)
- Previously this script used the previous calendar year as the check
  range, but this patch switches this to the past 365 days. This was
  approved by the SC and commit delegation team, see https://github.com/NixOS/nixpkgs-committers/issues/62

  This is also convenient because the new API call doesn't work with
  calendar years

Ping @Mic92 @jtojnar @winterqt @NickCao